### PR TITLE
Reword unauthorized messages to mention Onyen.

### DIFF
--- a/src/main/java/cdr/forms/FormController.java
+++ b/src/main/java/cdr/forms/FormController.java
@@ -599,7 +599,7 @@ public class FormController {
 		ModelAndView modelview = new ModelAndView("403");
 		modelview.addObject("formId", e.getFormId());
 		modelview.addObject("form", e.getForm());
-		modelview.addObject("message", e.getMessage()+" \nSend email to "+this.getAdministratorEmail()+" to request access.");
+		modelview.addObject("administratorEmail", getAdministratorEmail());
 		return modelview;
 	}
 

--- a/src/main/java/cdr/forms/PermissionDeniedException.java
+++ b/src/main/java/cdr/forms/PermissionDeniedException.java
@@ -24,7 +24,6 @@ public class PermissionDeniedException extends RuntimeException {
 	 */
 	private static final long serialVersionUID = -2942249514946141228L;
 	
-	//private UserSecurityProfile userSecurityProfile = null;
 	private Form form = null;
 	private String formId = null;
 
@@ -44,9 +43,7 @@ public class PermissionDeniedException extends RuntimeException {
 		this.formId = formId;
 	}
 
-	public PermissionDeniedException(String message, Form form, String formId) {
-		super(message);
-		//this.userSecurityProfile = userSecurityProfile;
+	public PermissionDeniedException(Form form, String formId) {
 		this.form = form;
 		this.formId = formId;
 	}

--- a/src/main/java/cdr/forms/RequestHeaderAuthorizationHandler.java
+++ b/src/main/java/cdr/forms/RequestHeaderAuthorizationHandler.java
@@ -61,24 +61,32 @@ public class RequestHeaderAuthorizationHandler implements AuthorizationHandler {
 	@Override
 	public void checkPermission(String formId, Form form, HttpServletRequest request) throws PermissionDeniedException {
 		// if groups are not specified or the form is public, then no further checks
-		if(form.getAuthorizedGroups() == null || form.getAuthorizedGroups().contains("public")) return;
+		if (form.getAuthorizedGroups() == null || form.getAuthorizedGroups().contains("public")) {
+			return;
+		}
 		
 		// any user is considered authenticated
-		if(form.getAuthorizedGroups().contains("authenticated") && request.getRemoteUser() != null) return;
+		if (form.getAuthorizedGroups().contains("authenticated") && request.getRemoteUser() != null) {
+			return;
+		}
 		
-		// get header string
 		String groupsHeader = request.getHeader(getGroupsHeaderName());
-		if(request.getRemoteUser() == null) {
-			throw new PermissionDeniedException("You must first log in to use this deposit form.", form, formId);
+		
+		if (request.getRemoteUser() == null) {
+			throw new PermissionDeniedException(form, formId);
 		} else {
-			if(groupsHeader == null) {
-				throw new PermissionDeniedException("Your login is not authorized to use this form.", form, formId);
+			if (groupsHeader == null) {
+				throw new PermissionDeniedException(form, formId);
 			}
-			for(String group : groupsHeader.split(getSplitCharacter())) {
-				if(this.groupsAlwaysPermitted.contains(group)) return;
-				if(form.getAuthorizedGroups().contains(group)) return;
+			for (String group : groupsHeader.split(getSplitCharacter())) {
+				if (this.groupsAlwaysPermitted.contains(group)) {
+					return;
+				}
+				if (form.getAuthorizedGroups().contains(group)) {
+					return;
+				}
 			}
-			throw new PermissionDeniedException("Your login is not authorized to use this form.", form, formId);
+			throw new PermissionDeniedException(form, formId);
 		}
 	}
 

--- a/src/main/webapp/WEB-INF/jsp/403.jsp
+++ b/src/main/webapp/WEB-INF/jsp/403.jsp
@@ -43,13 +43,27 @@
 
 <h2><c:out value="${form.title}"/></h2>
 <p><c:out value="${form.description}" escapeXml="false"/></p>
-<% if(request.getRemoteUser() != null) { %>
-<h3>Not Authorized to Deposit</h3>
-<p><c:out value="${message}"/></p>
+<% if (request.getRemoteUser() != null) { %>
+  <h3>Not Authorized</h3>
+  <p>
+    Your Onyen is not authorized to deposit using this form.
+    Please contact
+    <c:choose>
+      <c:when test="${form.contactEmail != null && form.contactName != null}">
+        <c:out value="${form.contactName}"/> at <a href="mailto:${form.contactEmail}"><c:out value="${form.contactEmail}"/></a>
+      </c:when>
+      <c:when test="${form.contactEmail != null}">
+        <a href="mailto:${form.contactEmail}"><c:out value="${form.contactEmail}"/></a>
+      </c:when>
+      <c:otherwise>
+        <a href="mailto:${administratorEmail}"><c:out value="${administratorEmail}"/></a>
+      </c:otherwise>
+    </c:choose>
+    to request access.</p>
 <% } else { %>
-<h3>Log In is Required</h3>
-<p><c:out value="${message}"/></p>
-<p id="login_block"><a href="/Shibboleth.sso/Login?target=%2fforms%2f${formId}.form">Log In</a></p>
+  <h3>Onyen Login Required</h3>
+  <p>You must log in with your Onyen to deposit using this form.</p>
+  <p id="login_block"><a href="/Shibboleth.sso/Login?target=%2fforms%2f${formId}.form">Log in with your Onyen</a></p>
 <% } %>
 </div>
 </div>


### PR DESCRIPTION
- Move actual messages out of RequestHeaderAuthorizationHandler and into the template.
- Remove message attribute from PermissionDeniedException.
- Update notices and login link on error page.
- Change "email ... to request access" to show the form's contact if present. (To match success message).